### PR TITLE
Don't publish original source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "seafox",
   "version": "0.0.4",
   "description": "A blazing fast 100% spec compliant, self-hosted javascript parser written in Typescript",
-  "main": "dist/seafox.umd.js",
-  "module": "dist/seafox.esm.js",
-  "jsnext:main": "dist/seafox.esm.js",
-  "browser": "dist/seafox.umd.js",
+  "main": "dist/seafox.umd.min.js",
+  "module": "dist/seafox.esm.min.js",
+  "jsnext:main": "dist/seafox.esm.min.js",
+  "browser": "dist/seafox.umd.min.js",
   "types": "dist/seafox.d.ts",
   "typings": "dist/seafox.d.ts",
   "author": "KFlash",
@@ -36,8 +36,8 @@
     "lightweight"
   ],
   "files": [
-    "dist",
-    "src",
+    "dist/*.min.js",
+    "dist/**/*.d.ts",
     "README.md",
     "LICENSE.md"
   ],


### PR DESCRIPTION
All the code published on npm is publicly readable. If it needs
to be kept private, it shouldn't be published on npm.

- Exclude the "src" directory
- Only included minified and .d.ts files

After my suggestion of using `.npmignore` (which acts as a blacklist) I noticed that you already use `"files"` (a whitelist), to I tuned that option to avoid publishing source files.

When you publish something on npm, you can check what has been included using https://unpkg.com/browse/seafox/.
If you want to remove your source code from npm, you can run these commands:
```
npm unpublish seafox@0.0.2
npm unpublish seafox@0.0.3
npm unpublish seafox@0.0.4
```
Note that you might need to wait 24 hours to re-publish it if you first unpublish  the old versions. (https://docs.npmjs.com/cli/unpublish#description)

---

This are the files included after this PR:
```
➜ npm pack
npm notice 
npm notice 📦  seafox@0.0.4
npm notice === Tarball Contents === 
npm notice 89.9kB dist/seafox.esm.min.js          
npm notice 90.2kB dist/seafox.umd.min.js          
npm notice 3.0kB  package.json                    
npm notice 760B   LICENSE.md                      
npm notice 1.8kB  README.md                       
npm notice 358B   dist/scanner/charClassifier.d.ts
npm notice 2.7kB  dist/chars.d.ts                 
npm notice 2.7kB  dist/scanner/chars.d.ts         
npm notice 504B   dist/scanner/comments.d.ts      
npm notice 4.3kB  dist/parser/common.d.ts         
npm notice 270B   dist/scanner/common.d.ts        
npm notice 478B   dist/parser/core.d.ts           
npm notice 1.5kB  dist/parser/declaration.d.ts    
npm notice 489B   dist/errors.d.ts                
npm notice 18.4kB dist/parser/estree.d.ts         
npm notice 12.6kB dist/parser/expressions.d.ts    
npm notice 742B   dist/scanner/identifier.d.ts    
npm notice 877B   dist/scanner/index.d.ts         
npm notice 876B   dist/parser/module.d.ts         
npm notice 1.1kB  dist/scanner/numeric.d.ts       
npm notice 250B   dist/scanner/regexp.d.ts        
npm notice 512B   dist/scanner/scan.d.ts          
npm notice 1.4kB  dist/parser/scope.d.ts          
npm notice 327B   dist/seafox.d.ts                
npm notice 10.7kB dist/parser/statements.d.ts     
npm notice 651B   dist/scanner/string.d.ts        
npm notice 321B   dist/scanner/template.d.ts      
npm notice 4.5kB  dist/token.d.ts                 
npm notice 87B    dist/scanner/unicode.d.ts       
npm notice === Tarball Details === 
npm notice name:          seafox                                  
npm notice version:       0.0.4                                   
npm notice filename:      seafox-0.0.4.tgz                        
npm notice package size:  60.3 kB                                 
npm notice unpacked size: 252.2 kB                                
npm notice shasum:        bcd13da1c8d8fe39c1a031dd9d8f8109a81825dd
npm notice integrity:     sha512-zEDcIu6Upfx5Z[...]SS+0qu8twIMmw==
npm notice total files:   29  
```